### PR TITLE
Document ALBA_DB_PATH and use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 Tornar executável:
 
 $ pyinstaller --onefile --windowed main.py
+
+## Configuração do banco de dados
+
+O caminho para o arquivo SQLite pode ser especificado através da variável de
+ambiente `ALBA_DB_PATH`. Caso não seja definido, o aplicativo utiliza o caminho
+`alba_zip_extracted/alba.sqlite`.
+
+Exemplo de execução com um caminho customizado:
+
+```bash
+export ALBA_DB_PATH=/caminho/para/alba.sqlite
+python main.py
+```

--- a/windows/base_window.py
+++ b/windows/base_window.py
@@ -1,8 +1,12 @@
+import os
 import ttkbootstrap as ttkb
 from tkinter import messagebox
 import sqlite3
 
-DB_PATH = "alba_zip_extracted/alba.sqlite"
+# Allow the SQLite path to be configured via the ``ALBA_DB_PATH`` environment
+# variable.  Defaults to the original hard-coded location when the variable is
+# not set.
+DB_PATH = os.environ.get("ALBA_DB_PATH", "alba_zip_extracted/alba.sqlite")
 
 class BaseWindow(ttkb.Toplevel):
     """Janela base com utilidades comuns."""


### PR DESCRIPTION
## Summary
- let `BaseWindow` read a database path from the `ALBA_DB_PATH` env var
- document the env var in the README

## Testing
- `python -m py_compile windows/base_window.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f3fb13b10832898ee8da3b1d76ea4