### PR TITLE
Convert app to basic MDI

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from windows.system_config import SystemConfigWindow
 from windows.itens_producao import ItensProducaoWindow
 from windows.tipo import TipoWindow
 from windows.textos import TextosWindow
+from mdi import MDIContainer
 
 class App(ttkb.Window):
     def __init__(self):
@@ -29,6 +30,9 @@ class App(ttkb.Window):
         aplicar_estilo(self)
         self.title("Sistema Alba")
         self.geometry("1100x600")
+
+        self.mdi = MDIContainer(self)
+        self.mdi.pack(fill=tk.BOTH, expand=True)
 
         self.create_menus()
 
@@ -75,61 +79,61 @@ class App(ttkb.Window):
         self.config(menu=menubar)
 
     def abrir_empresas(self):
-        EmpresaWindow(self)
+        EmpresaWindow(self.mdi)
 
     def abrir_contatos(self):
-        ContatoWindow(self)
+        ContatoWindow(self.mdi)
 
     def abrir_usuarios(self):
-        UsuarioWindow(self)
+        UsuarioWindow(self.mdi)
 
     def abrir_cep(self):
-        CepWindow(self)
+        CepWindow(self.mdi)
 
     def abrir_ncm(self):
-        NcmWindow(self)
+        NcmWindow(self.mdi)
 
     def abrir_ativid(self):
-        AtividWindow(self)
+        AtividWindow(self.mdi)
 
     def abrir_cfop(self):
-        CfopWindow(self)
+        CfopWindow(self.mdi)
 
     def abrir_tiponf(self):
-        TiponfWindow(self)
+        TiponfWindow(self.mdi)
 
     def abrir_natop(self):
-        NatopWindow(self)
+        NatopWindow(self.mdi)
     
     def abrir_endereco(self):
-        EnderecoWindow(self)
+        EnderecoWindow(self.mdi)
     
     def abrir_pessoas(self):
-        PessoaWindow(self)
+        PessoaWindow(self.mdi)
 
     def abrir_produto_fiscal(self):
-        ProdutoFiscalWindow(self)
+        ProdutoFiscalWindow(self.mdi)
 
     def abrir_ordem_compra(self):
-        OrdemCompraWindow(self)
+        OrdemCompraWindow(self.mdi)
 
     def abrir_item_ordem_compra(self):
-        ItemOrdemCompraWindow(self)
+        ItemOrdemCompraWindow(self.mdi)
 
     def abrir_comissao(self):
-        ComissaoWindow(self)
+        ComissaoWindow(self.mdi)
 
     def abrir_system_config(self):
-        SystemConfigWindow(self)
+        SystemConfigWindow(self.mdi)
 
     def abrir_itens_producao(self):
-        ItensProducaoWindow(self)
+        ItensProducaoWindow(self.mdi)
 
     def abrir_tipo(self):
-        TipoWindow(self)
+        TipoWindow(self.mdi)
 
     def abrir_textos(self):
-        TextosWindow(self)
+        TextosWindow(self.mdi)
 
 if __name__ == "__main__":
     app = App()

--- a/mdi.py
+++ b/mdi.py
@@ -1,0 +1,53 @@
+import tkinter as tk
+import ttkbootstrap as ttkb
+
+class MDIContainer(ttkb.Frame):
+    """Container for MDI child windows."""
+
+    def __init__(self, master=None, **kwargs):
+        super().__init__(master, **kwargs)
+        self._offset = 10  # initial placement offset
+
+    def register_child(self, child):
+        """Place a child window with an incremental offset."""
+        x = self._offset
+        y = self._offset
+        child.place(x=x, y=y)
+        self._offset += 30
+
+class MDIChild(ttkb.Frame):
+    """A movable child window inside an MDIContainer."""
+
+    def __init__(self, master=None, title="", width=400, height=300, **kwargs):
+        super().__init__(master, relief="raised", borderwidth=2, **kwargs)
+
+        # Title bar
+        self.title_label = ttkb.Label(self, text=title, anchor="w", padding=2,
+                                      style="inverse.TLabel")
+        self.title_label.pack(fill=tk.X)
+
+        # Dragging support
+        self._drag_start = (0, 0)
+        self.title_label.bind("<ButtonPress-1>", self._on_start)
+        self.title_label.bind("<B1-Motion>", self._on_drag)
+
+        # Default size
+        self.config(width=width, height=height)
+
+        # Place inside container if possible
+        if hasattr(master, "register_child"):
+            master.register_child(self)
+
+    def _on_start(self, event):
+        self._drag_start = (event.x, event.y)
+
+    def _on_drag(self, event):
+        dx = event.x - self._drag_start[0]
+        dy = event.y - self._drag_start[1]
+        x = self.winfo_x() + dx
+        y = self.winfo_y() + dy
+        self.place_configure(x=x, y=y)
+
+    def set_title(self, text: str):
+        """Update the window title."""
+        self.title_label.config(text=text)

--- a/windows/ativid.py
+++ b/windows/ativid.py
@@ -9,9 +9,8 @@ class AtividWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Atividades")
-        self.geometry("700x500")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Atividades")
+        self.config(width=700, height=500)
         self.recnum = None
 
         # Frame principal

--- a/windows/base_window.py
+++ b/windows/base_window.py
@@ -1,6 +1,7 @@
 import os
 import ttkbootstrap as ttkb
 from tkinter import messagebox
+from mdi import MDIChild
 import sqlite3
 
 # Allow the SQLite path to be configured via the ``ALBA_DB_PATH`` environment
@@ -8,11 +9,15 @@ import sqlite3
 # not set.
 DB_PATH = os.environ.get("ALBA_DB_PATH", "alba_zip_extracted/alba.sqlite")
 
-class BaseWindow(ttkb.Toplevel):
+class BaseWindow(MDIChild):
     """Janela base com utilidades comuns."""
 
     def __init__(self, master=None, **kwargs):
         super().__init__(master, **kwargs)
+
+    def set_title(self, text):
+        """Wrapper to update the title label."""
+        super().set_title(text)
 
     def conectar(self):
         """Retorna uma conexão com o banco de dados."""

--- a/windows/cep.py
+++ b/windows/cep.py
@@ -9,9 +9,8 @@ class CepWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Consulta de CEPs")
-        self.geometry("800x500")
-        self.resizable(False, False)
+        self.set_title("Consulta de CEPs")
+        self.config(width=800, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/cfop.py
+++ b/windows/cfop.py
@@ -8,9 +8,8 @@ class CfopWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de CFOP")
-        self.geometry("900x600")
-        self.resizable(False, False)
+        self.set_title("Cadastro de CFOP")
+        self.config(width=900, height=600)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/comissao.py
+++ b/windows/comissao.py
@@ -9,9 +9,8 @@ class ComissaoWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Faixas de Comissão")
-        self.geometry("800x550")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Faixas de Comissão")
+        self.config(width=800, height=550)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/contatos.py
+++ b/windows/contatos.py
@@ -9,9 +9,8 @@ class ContatoWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Contatos")
-        self.geometry("900x600")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Contatos")
+        self.config(width=900, height=600)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/empresas.py
+++ b/windows/empresas.py
@@ -9,9 +9,8 @@ class EmpresaWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Empresas")
-        self.geometry("900x700")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Empresas")
+        self.config(width=900, height=700)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/endereco.py
+++ b/windows/endereco.py
@@ -9,9 +9,8 @@ class EnderecoWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Endereços (alba0002)")
-        self.geometry("900x550")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Endereços (alba0002)")
+        self.config(width=900, height=550)
 
         self.current_recnum = None
 

--- a/windows/item_ordem_compra.py
+++ b/windows/item_ordem_compra.py
@@ -10,9 +10,8 @@ class ItemOrdemCompraWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Itens da Ordem de Compra (alba0011)")
-        self.geometry("1100x650")
-        self.resizable(False, False)
+        self.set_title("Itens da Ordem de Compra (alba0011)")
+        self.config(width=1100, height=650)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/itens_producao.py
+++ b/windows/itens_producao.py
@@ -10,9 +10,8 @@ class ItensProducaoWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Itens de Produção (alba0009)")
-        self.geometry("1200x700")
-        self.resizable(False, False)
+        self.set_title("Itens de Produção (alba0009)")
+        self.config(width=1200, height=700)
         
         # Variável para armazenar o ID do item selecionado para edição
         self.item_selecionado = None

--- a/windows/natop.py
+++ b/windows/natop.py
@@ -10,9 +10,8 @@ class NatopWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Naturezas da Operação (NATOP)")
-        self.geometry("900x500")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Naturezas da Operação (NATOP)")
+        self.config(width=900, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/ncm.py
+++ b/windows/ncm.py
@@ -10,9 +10,8 @@ class NcmWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Consulta de NCM")
-        self.geometry("700x500")
-        self.resizable(False, False)
+        self.set_title("Consulta de NCM")
+        self.config(width=700, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/ordem_compra.py
+++ b/windows/ordem_compra.py
@@ -9,9 +9,8 @@ from windows.base_window import BaseWindow
 class OrdemCompraWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
-        self.title("Cadastro de Ordens de Compra (alba0010)")
-        self.geometry("1000x650")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Ordens de Compra (alba0010)")
+        self.config(width=1000, height=650)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/pessoas.py
+++ b/windows/pessoas.py
@@ -10,9 +10,8 @@ class PessoaWindow(BaseWindow):
         super().__init__(master)
         self.id_pessoa_atual = None
         aplicar_estilo(self)
-        self.title("Cadastro de Pessoas (alba0001)")
-        self.geometry("1100x700")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Pessoas (alba0001)")
+        self.config(width=1100, height=700)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/produto_fiscal.py
+++ b/windows/produto_fiscal.py
@@ -10,9 +10,8 @@ class ProdutoFiscalWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro Produto Fiscal")
-        self.geometry("1200x800")
-        self.resizable(True, True)
+        self.set_title("Cadastro Produto Fiscal")
+        self.config(width=1200, height=800)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/system_config.py
+++ b/windows/system_config.py
@@ -10,9 +10,8 @@ class SystemConfigWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Configurações do Sistema")
-        self.geometry("900x700")
-        self.resizable(False, False)
+        self.set_title("Configurações do Sistema")
+        self.config(width=900, height=700)
 
         self.campos = {}
         

--- a/windows/textos.py
+++ b/windows/textos.py
@@ -8,9 +8,8 @@ from windows.base_window import BaseWindow
 class TextosWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
-        self.title("Cadastro de Textos")
-        self.geometry("900x700")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Textos")
+        self.config(width=900, height=700)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/tipo.py
+++ b/windows/tipo.py
@@ -8,9 +8,8 @@ from windows.base_window import BaseWindow
 class TipoWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
-        self.title("Cadastro de Tipos de Clientes")
-        self.geometry("700x500")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Tipos de Clientes")
+        self.config(width=700, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/tiponf.py
+++ b/windows/tiponf.py
@@ -10,9 +10,8 @@ class TiponfWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Tipos de Nota Fiscal")
-        self.geometry("700x500")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Tipos de Nota Fiscal")
+        self.config(width=700, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)

--- a/windows/usuarios.py
+++ b/windows/usuarios.py
@@ -10,9 +10,8 @@ class UsuarioWindow(BaseWindow):
     def __init__(self, master=None):
         super().__init__(master)
         aplicar_estilo(self)
-        self.title("Cadastro de Usuários")
-        self.geometry("700x500")
-        self.resizable(False, False)
+        self.set_title("Cadastro de Usuários")
+        self.config(width=700, height=500)
 
         # Frame principal
         main_frame = ttkb.Frame(self, padding=10)


### PR DESCRIPTION
## Summary
- implement `mdi.py` with draggable `MDIChild` windows and container
- base windows now inherit from `MDIChild`
- create an `MDIContainer` in `App` and open all windows inside it
- update every window class to configure size and title via the new base class

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850737a1f708328aa1a61ecd6601f78