### PR TITLE
Add close button to child windows

### DIFF
--- a/mdi.py
+++ b/mdi.py
@@ -21,13 +21,24 @@ class MDIChild(ttkb.Frame):
     def __init__(self, master=None, title="", width=400, height=300, **kwargs):
         super().__init__(master, relief="raised", borderwidth=2, **kwargs)
 
-        # Title bar
-        self.title_label = ttkb.Label(self, text=title, anchor="w", padding=2,
-                                      style="inverse.TLabel")
-        self.title_label.pack(fill=tk.X)
+        # Title bar with close button
+        self.title_bar = ttkb.Frame(self, style="inverse.TFrame")
+        self.title_bar.pack(fill=tk.X)
+
+        self.title_label = ttkb.Label(
+            self.title_bar, text=title, anchor="w", padding=2, style="inverse.TLabel"
+        )
+        self.title_label.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+        self.close_button = ttkb.Button(
+            self.title_bar, text="✖", width=3, command=self.destroy
+        )
+        self.close_button.pack(side=tk.RIGHT)
 
         # Dragging support
         self._drag_start = (0, 0)
+        self.title_bar.bind("<ButtonPress-1>", self._on_start)
+        self.title_bar.bind("<B1-Motion>", self._on_drag)
         self.title_label.bind("<ButtonPress-1>", self._on_start)
         self.title_label.bind("<B1-Motion>", self._on_drag)
 


### PR DESCRIPTION
## Summary
- enhance `MDIChild` to include a close button on its title bar

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68507a2bf6b08328b2133991609f4e8f